### PR TITLE
removed providers configuration file

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,0 @@
-{ 
-  "db": {
-    "postgis": {
-      "conn": "postgres://localhost/koopdev"
-    }
-  }
-}


### PR DESCRIPTION
closes #9 

i just blew away the config folder entirely and `npm test` still runs :ok_hand: locally.