### PR TITLE
fix log location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 * Added `status.version` to provider exports
 
+### Fixed
+* Corrected test log location
+
 ## [1.0.0] - 2015-07-28
 
 ### Added

--- a/test/model-test.js
+++ b/test/model-test.js
@@ -13,7 +13,7 @@ before(function (done) {
   var config = {}
   config.data_dir = __dirname + '/output/'
   koop.config = config
-  koop.log = new koop.Logger({logfile: './test.log'})
+  koop.log = new koop.Logger({ logfile: './' })
 
   koop.Cache = new koop.DataCache(koop)
   koop.Cache.db = koop.LocalDB


### PR DESCRIPTION
Noticed this fix in @chelm's commit on `koop-agol` (https://github.com/koopjs/koop-agol/commit/c73e344e940a525452e3cc1012814bd7a8361c4e) -- is this something we should be doing all over the place?