### PR TITLE
add status.version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 * Bump Esri Leaflet version used by preview to 1.0.0
 
+### Added
+* Added `status.version` to provider exports
+
 ## [1.0.0] - 2015-07-28
 
 ### Added

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
+var pkg = require('./package')
+
 var provider = {
   name: 'Github',
   model: require('./models/Github'),
   controller: require('./controller'),
-  routes: require('./routes')
+  routes: require('./routes'),
+  status: {
+    version: pkg.version
+  }
 }
 
 module.exports = provider


### PR DESCRIPTION
`status.version` should be in all providers (see https://github.com/koopjs/koopjs.github.io/issues/10)