### PR TITLE
Added sentence noting to use :: as a dir separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ app.listen(process.env.PORT || 1337, function () {
 
 There is an example server in the [`example`](example) directory.
 
-Once `koop-github` is registered as provider and you've started your Koop server, you can preview GeoJSON files in Github repositories using this pattern:
+Once `koop-github` is registered as provider and you've started your Koop server, you can preview GeoJSON files in Github repositories using this pattern.  Note that the path within the repo uses `::` as a directory separator:
 
 ```
 /github/{organization name}/{repository name}/{folder::path::to::geojson}/preview


### PR DESCRIPTION
Hopefully this will help dummies like me who didn't notice `::` in the example code until after I'd half written an issue about paths not working.